### PR TITLE
Fix Strang printing

### DIFF
--- a/src/strang.jl
+++ b/src/strang.jl
@@ -6,8 +6,12 @@ end
 Strang(n::Int) = Strang{Float64}(n)
 strang(T, n)= n >1 ? SymTridiagonal(2ones(T, n),-ones(T, n-1)) :
               n==1 ? Diagonal([2one(T)]) : error("Invalid dimension ", n)
-
-getindex{T}(S::Strang{T}, i, j) = getindex(strang(T, S.n), i, j)
+function getindex{T}(S::Strang{T}, i, j)
+	i == j && return 2
+	abs(i - j) == 1 && return -1
+	0
+end
+getindex{T}(S::Strang{T}, I...) = getindex(S,ind2sub(size(S),I)...)
 size(S::Strang, r::Int) = r==1 || r==2 ? S.n : throw(ArgumentError("Invalid dimension $r"))
 size(S::Strang) = S.n, S.n
 full{T}(S::Strang{T}) = full(strang(T, S.n))

--- a/src/strang.jl
+++ b/src/strang.jl
@@ -1,15 +1,15 @@
 export Strang
 
 immutable Strang{T} <: AbstractArray{T, 2}
-	n :: Int
+    n :: Int
 end
 Strang(n::Int) = Strang{Float64}(n)
 strang(T, n)= n >1 ? SymTridiagonal(2ones(T, n),-ones(T, n-1)) :
               n==1 ? Diagonal([2one(T)]) : error("Invalid dimension ", n)
 function getindex{T}(S::Strang{T}, i, j)
-	i == j && return 2
-	abs(i - j) == 1 && return -1
-	0
+    i == j && return 2
+    abs(i - j) == 1 && return -1
+    0
 end
 getindex{T}(S::Strang{T}, I...) = getindex(S,ind2sub(size(S),I)...)
 size(S::Strang, r::Int) = r==1 || r==2 ? S.n : throw(ArgumentError("Invalid dimension $r"))

--- a/test/strang.jl
+++ b/test/strang.jl
@@ -4,6 +4,12 @@ Z = Strang(1)
 n = rand(1:10)
 Z = Strang(n)
 
+for i in 1:n, j in 1:n
+    i==j && @test Z[i,j] == 2
+    abs(i-j)==1 && @test Z[i,j] == -1
+    abs(i-j)>1 && @test Z[i,j] == 0
+end
+
 #Matvec product
 b = randn(n)
 @test_approx_eq Z*b full(Z)*b


### PR DESCRIPTION
Makes a non-allocating `getindex` and makes the general `getindex` goes through this route. That in turn fixes the errors that occured when printing/displaying a Strang matrix.