### PR TITLE
fix A_mul_B!

### DIFF
--- a/src/strang.jl
+++ b/src/strang.jl
@@ -11,7 +11,7 @@ function getindex{T}(S::Strang{T}, i, j)
     abs(i - j) == 1 && return -1
     0
 end
-getindex{T}(S::Strang{T}, I...) = getindex(S,ind2sub(size(S),I)...)
+getindex{T}(S::Strang{T}, I...) = getindex(S,ind2sub(size(S),I...)...)
 size(S::Strang, r::Int) = r==1 || r==2 ? S.n : throw(ArgumentError("Invalid dimension $r"))
 size(S::Strang) = S.n, S.n
 full{T}(S::Strang{T}) = full(strang(T, S.n))

--- a/test/strang.jl
+++ b/test/strang.jl
@@ -10,6 +10,12 @@ for i in 1:n, j in 1:n
     abs(i-j)>1 && @test Z[i,j] == 0
 end
 
+A = Strang(10)
+u = ones(10)
+v = similar(u)
+A_mul_B!(v,A,u)
+@test v == [1.0;zeros(8);1.0]
+
 #Matvec product
 b = randn(n)
 @test_approx_eq Z*b full(Z)*b


### PR DESCRIPTION
The previous change to `getindex` broke `A_mul_B!` for `Strang` because it couldn't handle Cartesian appropriately. This splats it to make it work.