### PR TITLE
Fast solver for Vandermonde systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,13 +254,45 @@ julia> Toeplitz(collect(-4:4))
 ```
 ## [`Vandermonde`](http://en.wikipedia.org/wiki/Vandermonde_matrix) matrix
 
-
 ```julia
-julia> Vandermonde(collect(1:5))
-5x5 Vandermonde{Int64}:
- 1  1   1    1    1
- 1  2   4    8   16
- 1  3   9   27   81
- 1  4  16   64  256
- 1  5  25  125  625
+julia> a = collect(1.0:5.0)
+julia> A = Vandermonde(a)
+5×5 Vandermonde{Float64}:
+ 1.0  1.0   1.0    1.0    1.0
+ 1.0  2.0   4.0    8.0   16.0
+ 1.0  3.0   9.0   27.0   81.0
+ 1.0  4.0  16.0   64.0  256.0
+ 1.0  5.0  25.0  125.0  625.0
+```
+
+Adjoint Vandermonde:
+```julia
+julia> A'
+5×5 LinearAlgebra.Adjoint{Float64,Vandermonde{Float64}}:
+ 1.0   1.0   1.0    1.0    1.0
+ 1.0   2.0   3.0    4.0    5.0
+ 1.0   4.0   9.0   16.0   25.0
+ 1.0   8.0  27.0   64.0  125.0
+ 1.0  16.0  81.0  256.0  625.0
+```
+
+The backslash overator `\` is overloaded to solve Vandermonde and adjoint Vandermonde systems in ``O(n^2)`` time using the algorithm of [Björck & Pereyra (1970)](https://doi.org/10.2307/2004623
+),
+```julia
+julia> A\a
+5-element Array{Float64,1}:
+ 0.0
+ 1.0
+ 0.0
+ 0.0
+ 0.0
+
+julia> r2 = A[2,:]
+julia> A'\r2
+5-element Array{Float64,1}:
+ 0.0
+ 1.0
+ 0.0
+ 0.0
+ 0.0
 ```

--- a/src/SpecialMatrices.jl
+++ b/src/SpecialMatrices.jl
@@ -9,7 +9,8 @@ if VERSION >= v"0.7.0"
 end
 
 import Base: getindex, isassigned, size, *
-
+import Base.\
+    
 include("cauchy.jl") #Cauchy matrix
 include("companion.jl") #Companion matrix
 include("frobenius.jl") #Frobenius matrix

--- a/src/vandermonde.jl
+++ b/src/vandermonde.jl
@@ -1,7 +1,7 @@
 export Vandermonde
 
 struct Vandermonde{T} <: AbstractArray{T, 2}
-	c :: Vector{T}
+    c :: Vector{T}
 end
 
 getindex(V::Vandermonde, i::Int, j::Int) = V.c[i]^(j-1)
@@ -12,10 +12,125 @@ size(V::Vandermonde, r::Int) = (r==1 || r==2) ? length(V.c) :
 size(V::Vandermonde) = length(V.c), length(V.c)
 
 function Matrix(V::Vandermonde{T}) where T
-	n=size(V, 1)
-	M=Array{T}(undef, n, n)
-	for i=1:n
-		M[:,i] = V.c.^(i-1)
-	end
-	M
+    n=size(V, 1)
+    M=Array{T}(undef, n, n)
+    M[:,1] .= 1
+    for j=2:n
+        for i=1:n
+	    M[i,j] = M[i,j-1]*V.c[i]
+        end
+    end
+    M
 end
+
+if VERSION >= v"0.7.0" # Only use Adjoint and Transpose for 0.7 and up
+
+function Matrix(V::Adjoint{T,Vandermonde{T}}) where T
+    n=size(V, 1)
+    M=Array{T}(undef, n, n)
+    M[1,:] .= 1
+    for j=1:n
+        for i=2:n
+	    M[i,j] = M[i-1,j]*adjoint(V.parent.c[j])
+        end
+    end
+    M
+end
+
+function Matrix(V::Transpose{T,Vandermonde{T}}) where T
+    n=size(V, 1)
+    M=Array{T}(undef, n, n)
+    M[1,:] .= 1
+    for j=1:n
+        for i=2:n
+	    M[i,j] = M[i-1,j]*V.parent.c[j]
+        end
+    end
+    M
+end
+
+function \(V::Adjoint{T1,Vandermonde{T1}}, y::Vector{T2}) where T1 where T2
+    T = vandtype(T1,T2)
+    x = Array{T}(undef, length(y))
+    pvand!(x, adjoint(V.parent.c), y)
+end    
+
+function \(V::Transpose{T1,Vandermonde{T1}}, y::Vector{T2}) where T1 where T2
+    T = vandtype(T1,T2)
+    x = Array{T}(undef, length(y))
+    pvand!(x, V.parent.c, y)
+end
+
+end # End version check
+
+function \(V::Vandermonde{T1}, y::Vector{T2}) where T1 where T2
+    T = vandtype(T1,T2)
+    x = Array{T}(undef, length(y))    
+    dvand!(x, V.c, y)
+end
+
+
+function vandtype(T1::Type, T2::Type)
+    # Figure out the return type of Vandermonde{T1} \ Vector{T2}
+    T = promote_type(T1, T2)
+    S = typeof(oneunit(T)/oneunit(T1))
+    return S
+end
+
+"""
+    pvand!(x, alpha, b) -> x
+
+Solves transposed system ``A^T*x = b`` \\
+A is Vandermonde matrix, \\
+``A_{ij} = α_i^{j-1}``
+
+Algorithm by Bjorck & Pereyra,
+Mathematics of Computation, Vol. 24, No. 112 (1970), pp. 893-903,
+https://doi.org/10.2307/2004623
+"""
+function pvand!(x, alpha, b)
+    n = length(alpha);
+    copyto!(x,b)
+    for k=1:n
+        for j=n:-1:k+1
+            x[j] = x[j]-alpha[k]*x[j-1]
+        end
+    end
+    for k=n-1:-1:1
+        for j=k+1:n
+            x[j] = x[j]/(alpha[j]-alpha[j-k])
+        end
+        for j=k:n-1
+            x[j] = x[j]-x[j+1]
+        end
+    end
+    return x
+end
+
+"""
+    dvand(x, alpha, b) -> x
+
+Solves system ``A*x = b`` \\
+A is Vandermonde matrix, \\
+``A_{ij} = α_i^{j-1}``
+
+Algorithm by Bjorck & Pereyra,
+Mathematics of Computation, Vol. 24, No. 112 (1970), pp. 893-903,
+https://doi.org/10.2307/2004623
+"""
+function dvand!(x, alpha, b)
+    n = length(alpha)
+    copyto!(x,b)
+    for k=1:n-1
+        for j=n:-1:k+1
+            x[j] = (x[j]-x[j-1])/(alpha[j]-alpha[j-k])
+        end
+    end
+    for k=n-1:-1:1
+        for j=k:n-1
+            x[j] = x[j]-alpha[k]*x[j+1]
+        end
+    end
+    return x
+end
+

--- a/test/vandermonde.jl
+++ b/test/vandermonde.jl
@@ -1,3 +1,33 @@
-V=Vandermonde(collect(1:5))
-@test V[4,5] == 256
+using SpecialMatrices
+using Compat.Test
+
+a = [1,2,3+1im,8,5]
+V=Vandermonde(a)
+
+# Test element
+@test V[4,5] == a[4]^4
+
+# Test full matrix conversions
+M = Matrix(V)
+@test Matrix(V') == M'
+@test Matrix(transpose(V)) == transpose(M)
+
+# Test solving
+y = [1im,1,5,0,2]
+@test isapprox(V\y, M\y)
+@test isapprox(V'\y, M'\y)
+@test isapprox(y'/V, y'/M)
+@test isapprox(transpose(V)\y, transpose(M)\y)
+
+# Test that overloading works
+x2 = zero(M\y)
+SpecialMatrices.dvand!(x2, a, y)
+@test V\y==x2
+if VERSION >= v"0.7.0"
+    SpecialMatrices.pvand!(x2, a', y)
+    @test V'\y==x2
+    @test y'/V==x2'
+    SpecialMatrices.pvand!(x2, a, y)
+    @test transpose(V)\y==x2    
+end
 


### PR DESCRIPTION
- This implements the Björck-Pereyra algorithm for fast solution of Vandermonde systems.
- Backslash `\` is overloaded for `Vandermonde` in a way that should work as expected.