### PR TITLE
Streamline Vandermonde

### DIFF
--- a/src/vandermonde.jl
+++ b/src/vandermonde.jl
@@ -1,7 +1,11 @@
 export Vandermonde
 
 """
+    V = Vandermonde(c::AbstractVector)
+
+Create a "lazy" `n × n`
 [`Vandermonde` matrix](http://en.wikipedia.org/wiki/Vandermonde_matrix)
+but requiring only `O(n)` storage for the vector `c`.
 
 ```jldoctest van
 julia> a = 1:5; A = Vandermonde(a)

--- a/src/vandermonde.jl
+++ b/src/vandermonde.jl
@@ -117,7 +117,7 @@ function Matrix(V::Transpose{T,Vandermonde{T}}) where T
 end
 =#
 
-function \(V::Adjoint{T1,Vandermonde{T1,C}}, y::AbstractVecOrMat{T2}) where {T1, C, T2}
+function \(V::Adjoint{T1,<:Vandermonde{T1}}, y::AbstractVecOrMat{T2}) where {T1, T2}
     T = vandtype(T1,T2)
     x = Array{T}(undef, size(y))
     copyto!(x, y)

--- a/src/vandermonde.jl
+++ b/src/vandermonde.jl
@@ -125,7 +125,7 @@ function \(V::Adjoint{T1,<:Vandermonde{T1}}, y::AbstractVecOrMat{T2}) where {T1,
     return x
 end
 
-function \(V::Transpose{T1,Vandermonde{T1,C}}, y::AbstractVecOrMat{T2}) where {T1, C, T2}
+function \(V::Transpose{T1,<:Vandermonde{T1}}, y::AbstractVecOrMat{T2}) where {T1, T2}
     T = vandtype(T1,T2)
     x = Array{T}(undef, size(y))
     copyto!(x, y)

--- a/src/vandermonde.jl
+++ b/src/vandermonde.jl
@@ -1,7 +1,7 @@
 export Vandermonde
 
 """
-    V = Vandermonde(c::AbstractVector)
+    Vandermonde(c::AbstractVector)
 
 Create a "lazy" `n × n`
 [`Vandermonde` matrix](http://en.wikipedia.org/wiki/Vandermonde_matrix)

--- a/src/vandermonde.jl
+++ b/src/vandermonde.jl
@@ -9,7 +9,7 @@ but requiring only `O(n)` storage for the vector `c`.
 
 ```jldoctest van
 julia> a = 1:5; A = Vandermonde(a)
-5×5 Vandermonde{Int64}:
+5×5 Vandermonde{Int64, UnitRange{Int64}}:
  1  1   1    1    1
  1  2   4    8   16
  1  3   9   27   81
@@ -20,7 +20,7 @@ julia> a = 1:5; A = Vandermonde(a)
 Adjoint Vandermonde:
 ```jldoctest van
 julia> A'
-5×5 adjoint(::Vandermonde{Int64}) with eltype Int64:
+5×5 adjoint(::Vandermonde{Int64, UnitRange{Int64}}) with eltype Int64:
  1   1   1    1    1
  1   2   3    4    5
  1   4   9   16   25
@@ -52,12 +52,12 @@ julia> A' \\ A[2,:]
  0.0
 ```
 """
-struct Vandermonde{T} <: AbstractMatrix{T}
-    c :: AbstractVector{T}
+struct Vandermonde{T,C} <: AbstractMatrix{T}
+    c :: C
 
     function Vandermonde(c::AbstractVector{T}) where T
         axes(c,1) isa Base.OneTo || throw(ArgumentError("must be OneTo"))
-        new{T}(c)
+        new{T,typeof(c)}(c)
     end
 end
 
@@ -117,7 +117,7 @@ function Matrix(V::Transpose{T,Vandermonde{T}}) where T
 end
 =#
 
-function \(V::Adjoint{T1,Vandermonde{T1}}, y::AbstractVecOrMat{T2}) where T1 where T2
+function \(V::Adjoint{T1,Vandermonde{T1,C}}, y::AbstractVecOrMat{T2}) where {T1, C, T2}
     T = vandtype(T1,T2)
     x = Array{T}(undef, size(y))
     copyto!(x, y)
@@ -125,7 +125,7 @@ function \(V::Adjoint{T1,Vandermonde{T1}}, y::AbstractVecOrMat{T2}) where T1 whe
     return x
 end
 
-function \(V::Transpose{T1,Vandermonde{T1}}, y::AbstractVecOrMat{T2}) where T1 where T2
+function \(V::Transpose{T1,Vandermonde{T1,C}}, y::AbstractVecOrMat{T2}) where {T1, C, T2}
     T = vandtype(T1,T2)
     x = Array{T}(undef, size(y))
     copyto!(x, y)
@@ -183,6 +183,7 @@ function pvand!(alpha, B)
             end
         end
     end
+    return B
 end
 
 
@@ -216,4 +217,5 @@ function dvand!(alpha, B)
             end
         end
     end
+    return B
 end

--- a/test/vandermonde.jl
+++ b/test/vandermonde.jl
@@ -1,46 +1,63 @@
+# vandermonde.jl tests
+
+using SpecialMatrices: Vandermonde
+import SpecialMatrices # dvand!, pvand!
+using Test: @test, @testset, @test_throws, @inferred
+
+# abstract vector construction
+V = @inferred Vandermonde(5:7)
+@test V == (5:7) .^ (0:2)'
+
 a = [1,2,3+1im,8,5]
-V=Vandermonde(a)
+V = @inferred Vandermonde(a)
+M = @inferred Matrix(V)
 
 # Test element
-@test V[4,5] == a[4]^4
+@testset "basics" begin
+    @test V[4,5] == a[4]^4
+
+    @test isassigned(V, 2)
+    @test !isassigned(V, 26)
+    @test size(V) == (5, 5)
+end
 
 # Test full matrix conversions
-M = Matrix(V)
-@test Matrix(V') == M'
-@test Matrix(transpose(V)) == transpose(M)
+@testset "convert" begin
+    @test Matrix(V') == M'
+    @test Matrix(transpose(V)) == transpose(M)
+end
 
-# Test solving with vector and matrix rhs
-y = [1im,1,5,0,2]
-Y = [y 2*y]
-for rhs=[y, Y]
-    # Test solution
-    @test isapprox(V\rhs, M\rhs)
-    @test isapprox(V'\rhs, M'\rhs)
-    @test isapprox(rhs'/V, rhs'/M)
-    @test isapprox(transpose(V)\rhs, transpose(M)\rhs)
-    # Check that overloading works
-    x = zero(M\rhs)
-    copyto!(x, rhs)
-    SpecialMatrices.dvand!(a, x)
-    @test V\rhs==x
-    copyto!(x, rhs)
-    SpecialMatrices.pvand!(a', x)
-    @test V'\rhs==x
-    @test rhs'/V==x'
-    copyto!(x, rhs)
-    SpecialMatrices.pvand!(a, x)
-    @test transpose(V)\rhs==x
+@testset "solve" begin
+    # Test solving with vector and matrix rhs
+    y = [1im,1,5,0,2]
+    Y = [y 2*y]
+    for rhs in [y, Y]
+        # Test solution
+        @test isapprox(V \ rhs, M \ rhs)
+        @test isapprox(V' \ rhs, M' \ rhs)
+        @test isapprox(rhs' / V, rhs' / M)
+        @test isapprox(transpose(V) \ rhs, transpose(M) \ rhs)
+
+        # Check that overloading works
+        x = zero(M \ rhs)
+        copyto!(x, rhs)
+        SpecialMatrices.dvand!(a, x)
+        @test V \ rhs == x
+
+        copyto!(x, rhs)
+        SpecialMatrices.pvand!(a', x)
+        @test V' \ rhs == x
+        @test rhs' / V == x'
+
+        copyto!(x, rhs)
+        SpecialMatrices.pvand!(a, x)
+        @test transpose(V) \ rhs == x
+    end
 end
 
 # Test dimension errors
-rhs = zeros(2,2)
-try
-    V\rhs
-catch e
-    @test typeof(e)==DimensionMismatch
-end
-try
-    V'\rhs
-catch e
-    @test typeof(e)==DimensionMismatch
+@testset "dims" begin
+    rhs = zeros(2,2)
+    @test_throws DimensionMismatch V \ rhs
+    @test_throws DimensionMismatch V' \ rhs
 end

--- a/test/vandermonde.jl
+++ b/test/vandermonde.jl
@@ -42,15 +42,20 @@ end
         x = zero(M \ rhs)
         copyto!(x, rhs)
         SpecialMatrices.dvand!(a, x)
+#       @which V \ rhs
         @test V \ rhs == x
 
         copyto!(x, rhs)
         SpecialMatrices.pvand!(a', x)
+#       @which V' \ rhs
         @test V' \ rhs == x
+
+#       @which rhs' / V
         @test rhs' / V == x'
 
         copyto!(x, rhs)
         SpecialMatrices.pvand!(a, x)
+#       @which transpose(V) \ rhs
         @test transpose(V) \ rhs == x
     end
 end


### PR DESCRIPTION
This PR supports construction with `AbstractVector` arguments: `Vandermonde(1:3)` instead of having to use `collect`.

It also provides more detailed docstring including `jldoctests`.

It eliminates some (I believe) unnecessary code.  For now I have retained the code but enclosed it in block comments in case I have overlooked some reason to retain it.