### PR TITLE
Fix Riemann doctest

### DIFF
--- a/src/riemann.jl
+++ b/src/riemann.jl
@@ -11,11 +11,11 @@ defined as `A = B[2:N+1, 2:N+1]`, where
 `B[i,j] = i-1` if `i` divides `j`, and `-1` otherwise.
 The
 [Riemann hypothesis](http://en.wikipedia.org/wiki/Riemann_hypothesis) holds
-if and only if `det(A) = O( N! N^(-1/2+epsilon))` for every `epsilon > 0`.
+if and only if `det(A) = O(N! N^(-1/2+ϵ))` for every `ϵ > 0`.
 
 ```jldoctest
 julia> Riemann(7)
-7x7 Riemann{Int64}:
+7×7 Riemann{Int64}:
   1  -1   1  -1   1  -1   1
  -1   2  -1  -1   2  -1  -1
  -1  -1   3  -1  -1  -1   3
@@ -25,9 +25,10 @@ julia> Riemann(7)
  -1  -1  -1  -1  -1  -1   7
 ```
 
-For more details see Friedrich Roesler, Riemann's hypothesis as an eigenvalue problem,
-Linear Algebra and its Applications, Vol. 81, (1986)
-http://www.sciencedirect.com/science/article/pii/0024379586902557
+For more details see Friedrich Roesler,
+"Riemann's hypothesis as an eigenvalue problem,"
+Linear Algebra and its Applications, Vol. 81, p.153-198, Sep. 1986.
+https://doi.org/10.1016/0024-3795(86)90255-7
 """
 struct Riemann{Int} <: AbstractMatrix{Int}
     n::Int


### PR DESCRIPTION
The doctest for `riemann` was failing due to an `x` that should have been a `\times`.
This fixes that.  And I tweaked the citations and docs while in there.
Another purpose of this is to see if the docs will build.
No changes to actual code, so no version bump.