### PR TITLE
Test Julia 1.6 and abandon 1.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1'
           - 'nightly'
         os:
@@ -28,12 +28,12 @@ jobs:
             arch: x64
             coverage: true
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v3
+      - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         env:
           cache-name: cache-artifacts
         with:

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -15,7 +15,7 @@ jobs:
         run: which julia
         continue-on-error: true
       - name: Install Julia, but only if it is not already available in the PATH
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@latest
         with:
           version: '1'
           arch: ${{ runner.arch }}

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 
 [compat]
 Polynomials = "1, 2, 3"
-julia = "1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Currently this package tests Julia versions `1.0`, `1` (which is 1.8 right now) and `nightly`.
I propose that we abandon 1.0 because it is too much work to maintain tests for such an old version, and instead test 1.6 because 1.6 is the current long-term support version.
I ran into issues with 1.0 with #63 and had to put in a hack with `VERSION` to get around it.
Anyone still using 1.0 can still also use older versions of this package of course.
Any objections?