### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
@jishnub It turns out that the way to keep yml files current is to use dependabot:
https://github.com/orgs/community/discussions/37052
Since you were the one who proposed the change to `@v3` I thought you might want to know about this for other repos as well.