### PR TITLE
Use COV_EXCL_LINE

### DIFF
--- a/src/hilbert.jl
+++ b/src/hilbert.jl
@@ -88,8 +88,8 @@ size(A::InverseHilbert, dim::Integer) = dim==1 || dim==2 ? A.n : 1
 size(A::InverseHilbert) = size(A,1), size(A,2)
 
 # Properties
-ishermitian(::InverseHilbert) = true
-isposdef(::InverseHilbert) = true
+ishermitian(::InverseHilbert) = true # COV_EXCL_LINE
+isposdef(::InverseHilbert) = true # COV_EXCL_LINE
 
 # Index into a inverse Hilbert matrix
 function getindex(A::InverseHilbert{T}, i::Integer, j::Integer) where {T}

--- a/src/strang.jl
+++ b/src/strang.jl
@@ -42,9 +42,9 @@ Strang(n::Int) = Strang(Int, n)
 size(s::Strang) = (s.n, s.n)
 LinearAlgebra.adjoint(s::Strang) = s
 LinearAlgebra.transpose(s::Strang) = s
-LinearAlgebra.issymmetric(s::Strang) = true
-LinearAlgebra.ishermitian(s::Strang) = true
-LinearAlgebra.isposdef(s::Strang) = true
+LinearAlgebra.issymmetric(s::Strang) = true # COV_EXCL_LINE
+LinearAlgebra.ishermitian(s::Strang) = true # COV_EXCL_LINE
+LinearAlgebra.isposdef(s::Strang) = true # COV_EXCL_LINE
 
 @inline Base.@propagate_inbounds function getindex(A::Strang{T}, i::Integer, j::Integer) where T
     @boundscheck checkbounds(A, i, j)


### PR DESCRIPTION
codecov wrongly asserts that the 5 code lines affected here are not covered by the test suite.
They are covered, but the compiler optimizes away these trivial lines, which codecov does not realize.
The comment `COV_EXCL_LINE` tells codecov to ignore these lines, which reduces PR noise.